### PR TITLE
Updated Deposit Delegator Calculator Domain

### DIFF
--- a/src/views/AppIndex/CommunityAppIndexList.tsx
+++ b/src/views/AppIndex/CommunityAppIndexList.tsx
@@ -35,7 +35,7 @@ const APPS_TO_LIST: AppInfo[] = [
   {
     titleKey: 'multidelegatorCalculatorTitle',
     descriptionKey: 'multidelegatorCalculatorDescription',
-    href: 'https://pooltogether-multidelegator.netlify.app/',
+    href: 'https://prizecalc.com/',
     twitter: 'ncookie_eth',
     github: 'Ncookiez',
     repo: 'https://github.com/Ncookiez/pooltogether-multidelegator-preview'


### PR DESCRIPTION
Just added the new domain to the deposit delegator calculator.

_The old domain is still functional._