### PR TITLE
Fixed Tiers Decimal Issue

### DIFF
--- a/src/tools/PrizeTierController/config.ts
+++ b/src/tools/PrizeTierController/config.ts
@@ -24,6 +24,7 @@ export const PRIZE_TIER_CONTROLLER_SUPPORTED_CHAIN_IDS = Object.freeze({
 })
 
 export const DPR_DECIMALS: number = 7
+export const TIER_DECIMALS: number = 9
 
 export const PRIZE_TIER_HISTORY_V1: {
   [chainId: number]: { address: string; tokenAddress: string }

--- a/src/tools/PrizeTierController/utils/formatCombinedPrizeTier.ts
+++ b/src/tools/PrizeTierController/utils/formatCombinedPrizeTier.ts
@@ -1,6 +1,5 @@
+import { TIER_DECIMALS } from '@prizeTierController/config'
 import { PrizeTierConfigV2 } from '@prizeTierController/interfaces'
-
-// TODO: these functions should also check if tiers add up to 100% and add to the largest tier with a value if necessary
 
 export const formatCombinedPrizeTier = (
   prizeTier: PrizeTierConfigV2,
@@ -24,5 +23,15 @@ export const formatCombinedPrizeTier = (
       }
     }
   }
+
+  // Checking tiers for decimal issues:
+  const tiersSum = combinedPrizeTier.tiers.reduce((a, b) => a + b, 0)
+  if (tiersSum !== 10 ** TIER_DECIMALS) {
+    const firstNonEmptyTier = combinedPrizeTier.tiers.findIndex((value) => value > 0)
+    if (firstNonEmptyTier !== -1) {
+      combinedPrizeTier.tiers[firstNonEmptyTier] += 10 ** TIER_DECIMALS - tiersSum
+    }
+  }
+
   return combinedPrizeTier
 }


### PR DESCRIPTION
This fixes the prize tiers not summing up exactly to `1_000_000_000`.

It is mostly a visual fix since 1 decimal would likely not affect the value of any prizes, and definitely not in any significant way.