### PR TITLE
Improved Draw ID Validation

### DIFF
--- a/src/tools/PrizeTierController/SavePrizeTiersModal/DrawIdForm.tsx
+++ b/src/tools/PrizeTierController/SavePrizeTiersModal/DrawIdForm.tsx
@@ -70,7 +70,7 @@ const DrawIdInput = (props: {
             isValidInteger: (v) =>
               Number.isInteger(Number(v)) || t('fieldIsInvalid', { field: t('drawIdLabel') }),
             isGreaterThanOrEqualToZero: (v) =>
-              parseInt(v) >= 0 || t('fieldIsInvalid', { field: t('drawIdLabel') })
+              parseInt(v) > 0 || t('fieldIsInvalid', { field: t('drawIdLabel') })
           }
         })}
       />

--- a/src/tools/PrizeTierController/SavePrizeTiersModal/DrawIdForm.tsx
+++ b/src/tools/PrizeTierController/SavePrizeTiersModal/DrawIdForm.tsx
@@ -25,14 +25,19 @@ export const DrawIdForm = (props: {
 
   useEffect(() => {
     const numDrawId = Number(drawId)
-    if (Number.isInteger(numDrawId) && numDrawId > minDrawId) {
+    if (Number.isInteger(numDrawId) && numDrawId >= 0) {
       onChange(numDrawId)
     }
   }, [drawId])
 
   return (
     <form className='flex flex-col' autoComplete='off'>
-      <DrawIdInput minDrawId={minDrawId} errors={errors} register={register} />
+      <DrawIdInput
+        minDrawId={minDrawId}
+        errors={errors}
+        register={register}
+        drawId={Number(drawId)}
+      />
     </form>
   )
 }
@@ -41,8 +46,9 @@ const DrawIdInput = (props: {
   minDrawId: number
   errors: FieldErrorsImpl<{ drawId: string }>
   register: UseFormRegister<{ drawId: string }>
+  drawId: number
 }) => {
-  const { minDrawId, errors, register } = props
+  const { minDrawId, errors, register, drawId } = props
   const { t } = useTranslation()
 
   return (
@@ -63,14 +69,15 @@ const DrawIdInput = (props: {
           validate: {
             isValidInteger: (v) =>
               Number.isInteger(Number(v)) || t('fieldIsInvalid', { field: t('drawIdLabel') }),
-            isGreaterThanZero: (v) =>
-              parseInt(v) > 0 || t('fieldIsInvalid', { field: t('drawIdLabel') }),
-            isGreaterThanNewestId: (v) =>
-              parseInt(v) > minDrawId || t('fieldIsInvalid', { field: t('drawIdLabel') })
+            isGreaterThanOrEqualToZero: (v) =>
+              parseInt(v) >= 0 || t('fieldIsInvalid', { field: t('drawIdLabel') })
           }
         })}
       />
-      <ErrorMessage>
+      {Number(drawId) < minDrawId && (
+        <p className='text-yellow text-xxxs mt-2'>{t('warningDrawId')}</p>
+      )}
+      <ErrorMessage className='mb-3'>
         {!!errors.drawId?.message && typeof errors.drawId.message === 'string'
           ? errors.drawId.message
           : null}

--- a/src/tools/PrizeTierController/SavePrizeTiersModal/DrawIdForm.tsx
+++ b/src/tools/PrizeTierController/SavePrizeTiersModal/DrawIdForm.tsx
@@ -74,9 +74,7 @@ const DrawIdInput = (props: {
           }
         })}
       />
-      {Number(drawId) < minDrawId && (
-        <p className='text-yellow text-xxxs mt-2'>{t('warningDrawId')}</p>
-      )}
+      {drawId < minDrawId && <p className='text-yellow text-xxxs mt-2'>{t('warningDrawId')}</p>}
       <ErrorMessage className='mb-3'>
         {!!errors.drawId?.message && typeof errors.drawId.message === 'string'
           ? errors.drawId.message

--- a/src/tools/PrizeTierController/SavePrizeTiersModal/index.tsx
+++ b/src/tools/PrizeTierController/SavePrizeTiersModal/index.tsx
@@ -124,7 +124,7 @@ const SaveEdits = (props: { allEdits: PrizePoolEditHistory[] }) => {
         <>
           <DrawIdForm
             onChange={(value) => setDrawId(value)}
-            defaultValues={{ drawId: (nextDrawId + 1).toString() }}
+            defaultValues={{ drawId: nextDrawId.toString() }}
             minDrawId={nextDrawId}
           />
           <ul className='flex flex-col gap-4 mb-4'>


### PR DESCRIPTION
This PR changes two small details in the transactions modal:

- A draw ID smaller than the beacon draw ID is no longer invalid.
- A warning will be displayed for any draw ID selected that is smaller than the beacon draw ID.

**Example:**

![image](https://user-images.githubusercontent.com/22108522/206299962-2ebca9a8-8066-4583-837d-8711b48fb7e6.png)
